### PR TITLE
Adds sources target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ dist:
 	cd dist; tar cfz ../${PKGNAME}-${PKGVERSION}.tar.gz ${PKGNAME}-${PKGVERSION}
 	rm -rf dist
 
+sources: dist
+
 srpm: dist
 	  rpmbuild -ts --define='dist .el6' ${PKGNAME}-${PKGVERSION}.tar.gz
 


### PR DESCRIPTION
All ARGO components should use `make sources`
